### PR TITLE
Create harder dependencies for all involved services.

### DIFF
--- a/dabplus-on-air-processing.service
+++ b/dabplus-on-air-processing.service
@@ -10,5 +10,5 @@ ExecStop=/bin/echo "DAB+ On Air Processing going down."
 
 [Install]
 WantedBy=multi-user.target
-Also=liquidsoap@dabplus-on-air-processing.service
-Also=dabplus-mot-encoder@dabplus-on-air-processing.service
+RequiredBy=liquidsoap@dabplus-on-air-processing.service
+RequiredBy=dabplus-mot-encoder@dabplus-on-air-processing.service


### PR DESCRIPTION
`RequiredBy=` will create a symbolic link in the .requires/ directory during service installation of the following services:
- `liquidsoap@dabplus-on-air-processing.service`
- `dabplus-mot-encoder@dabplus-on-air-processing.service`

This will ensure that all services will be started and stopped while starting or stopping the main `dabplus-on-air-processing.service`.

Explicit installation via `Also=` is not required, as the individual services will be started and stopped anyway.

Note, that stopping a dependency will also stop the main service and thus the other deps. If you need finer grade control, enable the deps. manually and do not use the main service.
