### PR TITLE
Modularize call to encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ systemctl status liquidsoap@dabplus-on-air-processing
 systemctl status dabplus-odr-padenc@dabplus-on-air-processing
 ```
 
-You may put slides and DL text files into `/var/tmp/mot/dabplus-on-air-processing/{slides,texts}`.
+You may put slides and DL text files into `/var/tmp/odr/dabplus-on-air-processing/{slides,texts}`.
 
 Testing
 -------

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ systemctl status liquidsoap@dabplus-on-air-processing
 systemctl status dabplus-odr-padenc@dabplus-on-air-processing
 ```
 
-You may put slides and DL text files into `/var/tmp/odr/dabplus-on-air-processing/{slides,texts}`.
+You may put slides and DL text files into `/var/tmp/odr/padenc/dabplus-on-air-processing/{slides,texts}`.
 
 Testing
 -------

--- a/dabplus-on-air-processing.conf
+++ b/dabplus-on-air-processing.conf
@@ -32,7 +32,19 @@ wav_encoder = %wav(samplerate=48000)
 
 # configure the call to the dab encoder
 #
-external_encoder = "odr-audioenc -i - -b 96 -r 48000 -o tcp://127.0.0.1:9000 --pad=58 --pad-fifo=/var/tmp/odr/dabplus-on-air-processing/pad.fifo"
+# external encoder binary
+encoder_bin = "odr-audioenc"
+
+# where the encoder should stream zmq frame to
+encoder_output = "tcp://127.0.0.1:9000"
+
+# where to get mot pad info from
+encoder_padenc_fifo = "/var/tmp/odr/padenc/dabplus-on-air-processing/pad.fifo"
+
+# additional arguments to external excoder call:
+#
+encoder_args = "--bitrate=96 --rate=48000 --pad=58"
+
 
 
 # archive configuration

--- a/dabplus-on-air-processing.conf
+++ b/dabplus-on-air-processing.conf
@@ -32,7 +32,7 @@ wav_encoder = %wav(samplerate=48000)
 
 # configure the call to the dab encoder
 #
-external_encoder = "odr-audioenc -i - -b 96 -r 48000 -o tcp://127.0.0.1:9000 --pad=58 --pad-fifo=/var/tmp/mot/dabplus-on-air-processing/pad.fifo"
+external_encoder = "odr-audioenc -i - -b 96 -r 48000 -o tcp://127.0.0.1:9000 --pad=58 --pad-fifo=/var/tmp/odr/dabplus-on-air-processing/pad.fifo"
 
 
 # archive configuration

--- a/dabplus-on-air-processing.conf
+++ b/dabplus-on-air-processing.conf
@@ -35,13 +35,13 @@ wav_encoder = %wav(samplerate=48000)
 # external encoder binary
 encoder_bin = "odr-audioenc"
 
-# where the encoder should stream zmq frame to
+# where the encoder should stream zmq frames to
 encoder_output = "tcp://127.0.0.1:9000"
 
 # where to get mot pad info from
 encoder_padenc_fifo = "/var/tmp/odr/padenc/dabplus-on-air-processing/pad.fifo"
 
-# additional arguments to external excoder call:
+# additional arguments to external encoder call:
 #
 encoder_args = "--bitrate=96 --rate=48000 --pad=58"
 

--- a/dabplus-on-air-processing.conf
+++ b/dabplus-on-air-processing.conf
@@ -36,7 +36,9 @@ wav_encoder = %wav(samplerate=48000)
 encoder_bin = "odr-audioenc"
 
 # where the encoder should stream zmq frames to
-encoder_output = "tcp://127.0.0.1:9000"
+encoder_outputs = [
+  "tcp://127.0.0.1:9000"
+]
 
 # where to get mot pad info from
 encoder_padenc_fifo = "/var/tmp/odr/padenc/dabplus-on-air-processing/pad.fifo"

--- a/src/dabplus-on-air-processing.liq
+++ b/src/dabplus-on-air-processing.liq
@@ -40,13 +40,19 @@ output =
   end
 
 # send the processed signal to the ODR encoder
+def map_output_args(a)
+  string.concat(["--output=", a])
+end
+output_args = string.concat(
+  separator=" ",
+  list.map(map_output_args, encoder_outputs))
 odr_encoder =  string.concat(
   separator=" ", 
   [
     encoder_bin, 
     "--input=stdin",
-    "--output=#{encoder_output}",
     "--pad-fifo=#{encoder_padenc_fifo}",
+    output_args,
     encoder_args])
 
 log("Starting ODR encoder: #{odr_encoder}", label="dabplus")

--- a/src/dabplus-on-air-processing.liq
+++ b/src/dabplus-on-air-processing.liq
@@ -39,10 +39,20 @@ output =
     input
   end
 
-# send the processed signal to the encoder
+# send the processed signal to the ODR encoder
+odr_encoder =  string.concat(
+  separator=" ", 
+  [
+    encoder_bin, 
+    "--input=stdin",
+    "--output=#{encoder_output}",
+    "--pad-fifo=#{encoder_padenc_fifo}",
+    encoder_args])
+
+log("Starting ODR encoder: #{odr_encoder}", label="dabplus")
 output.external(
   wav_encoder,
-  external_encoder,
+  odr_encoder,
   output)
 
 # write archive files if feature is enabled


### PR DESCRIPTION
Problem: The configuration was quite obscure and and there where no hints on how to use it.

Solution: Modularized configuration with a concat that builds the actual call.

While this is less flexible if we want to swap out odr-audioenc, it is much more readable when we keep it.

Fixes #7 

